### PR TITLE
Facelift + Fix #67 - Use Maven settings.xml in the demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 Jenkins Config As Code Example.iml
 .build
+tmp/
+
+.factorypath
+.settings
+.project
+.classpath
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.138.3
+FROM jenkins/jenkins:2.164.1
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 LABEL Description="This is a base image for a single-shot ci.jenkins.io demo" Vendor="Oleg Nenashev" Version="0.3"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ node ("linux") {
         
         def makeCommand = "make build"
         if (hasSettingsXml) {
-            makeCommand += " -e CWP_OPTS='-mvnSettingsFile=${settingsXml}'"
+            makeCommand += " -e MVN_SETTINGS_FILE='${settingsXml}'"
         }
         infra.runWithMaven(makeCommand)
     }

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run:
 demo-plugin:
 	docker run --rm ${DOCKER_RUN_OPTS} \
 	    -v $(shell pwd)/demo/locale-plugin/:/workspace/ \
-	    $(DOCKER_TAG) ${DOCKER_RUN_OPTS}
+	    $(DOCKER_TAG)
 
 .PHONY: demo-plugin-local-lib
 demo-plugin-local-lib:

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ CWP_MAVEN_REPO_PATH=io/jenkins/tools/custom-war-packager/custom-war-packager-cli
 CWP_VERSION=1.5
 DOCKER_TAG=jenkins4eval/ci.jenkins.io-runner:local-test
 PIPELINE_LIBRARY_DIR=/Users/nenashev/Documents/jenkins/infra/pipeline-library/
-CWP_OPTS=""
+CWP_OPTS=
 DOCKER_RUN_OPTS="-v maven-repo:/root/.m2"
+# It will not work properly if Jenkins repo is not set, so missing settings is not an option here
+MVN_SETTINGS_FILE ?= $(HOME)/.m2/settings.xml
 
 #TODO: Replace snapshot parsing by something more reliable
 ifneq (,$(findstring 1.6-2018,$(CWP_VERSION)))
@@ -36,7 +38,8 @@ docker:
 
 build: .build/cwp-cli-${CWP_VERSION}.jar
 	java -jar .build/cwp-cli-${CWP_VERSION}.jar \
-	     -configPath packager-config.yml -version ${VERSION} ${CWP_OPTS}
+	     -configPath packager-config.yml -version ${VERSION} ${CWP_OPTS} \
+		 -mvnSettingsFile ${MVN_SETTINGS_FILE}
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CWP_VERSION=1.5
 DOCKER_TAG=jenkins4eval/ci.jenkins.io-runner:local-test
 PIPELINE_LIBRARY_DIR=/Users/nenashev/Documents/jenkins/infra/pipeline-library/
 CWP_OPTS=
-DOCKER_RUN_OPTS="-v maven-repo:/root/.m2"
+DOCKER_RUN_OPTS=-v maven-repo:/root/.m2
 # It will not work properly if Jenkins repo is not set, so missing settings is not an option here
 MVN_SETTINGS_FILE ?= $(HOME)/.m2/settings.xml
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ See the _Limitations_ section below for some of known limitations.
 
 ### Quickstart
 
-1. Checkout this repo
+0. Checkout this repo
+1. Configure Maven Settings file according to the [Jenkins Plugin Tutorial](https://wiki.jenkins.io/display/JENKINS/Plugin+tutorial) so that plugins can be properly downloaded for the pom.xml input
 2. Run `make docker` to build the base image
 3. Run `make clean build` to build the Jenkinsfile Runner image
 4. Run `make run` to run a simple demo

--- a/packager-config.yml
+++ b/packager-config.yml
@@ -15,7 +15,7 @@ buildSettings:
         noCache: true
       source:
         git: https://github.com/jenkinsci/jenkinsfile-runner.git
-        commit: 66626ef7c95c281d5b3ef9da9f5fdc36b4b42bf0
+        branch: 1.0-beta-7
     docker:
       base: "jenkins/ci.jenkins.io-runner.base"
       tag: "jenkins4eval/ci.jenkins.io-runner:local-test"
@@ -24,7 +24,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.138.3"
+    version: "2.164.1"
 systemProperties:
   jenkins.model.Jenkins.slaveAgentPort: "50000"
   jenkins.model.Jenkins.slaveAgentPortEnforce: "true"

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsch</artifactId>
+      <version>0.1.54.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
       <version>4.5.5-3.0</version>
     </dependency>


### PR DESCRIPTION
Settings.xml matters in this case, because otherwise we would poll plugins from Maven Central and then improperly assume that artifacts are not plugins. 

It would workaround #67, but I believe we will also need a patch in CWP to prevent false negatives in the cache.I will submit a bug for it

- [x] Fix #67 
- [x] Update Jenkins core to 2.164.1
- [x] Fix other recent glitches in the makefile

CC @tandibar tcollignon @varyvol @fcojfernandez @raul-arabaolaza 

