### PR TITLE
Update Custom WAR Packager from 1.5 to 2.0-alpha-2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 ARTIFACT_ID = jenkinsfile-runner-demo
 VERSION = 256.0-test
 CWP_MAVEN_REPO_PATH=io/jenkins/tools/custom-war-packager/custom-war-packager-cli
-CWP_VERSION=1.5
+CWP_VERSION=2.0-alpha-2
 DOCKER_TAG=jenkins4eval/ci.jenkins.io-runner:local-test
 PIPELINE_LIBRARY_DIR=/Users/nenashev/Documents/jenkins/infra/pipeline-library/
 CWP_OPTS=

--- a/packager-config.yml
+++ b/packager-config.yml
@@ -7,6 +7,7 @@ bundle:
 buildSettings:
   pom: "pom.xml"
   pomIgnoreRoot: true
+  pomIncludeWar: true
   jenkinsfileRunner:
     source:
       groupId: "io.jenkins"
@@ -20,11 +21,6 @@ buildSettings:
       base: "jenkins/ci.jenkins.io-runner.base"
       tag: "jenkins4eval/ci.jenkins.io-runner:local-test"
       build: true
-war:
-  groupId: "org.jenkins-ci.main"
-  artifactId: "jenkins-war"
-  source:
-    version: "2.164.1"
 systemProperties:
   jenkins.model.Jenkins.slaveAgentPort: "50000"
   jenkins.model.Jenkins.slaveAgentPortEnforce: "true"

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <jenkins.version>2.138.3</jenkins.version>
+    <jenkins.version>2.164.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 


### PR DESCRIPTION
Manual update, which moves the Jenkins Core definition to pom.xml and optimizes the build speed by using Update Center source instead of Maven