### PR TITLE
Switch ci.jenkins.io.runner to Warnings NG + Update JFR from 1.0-beta-16 to 1.0-beta-17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,11 @@
     <version>1.0-beta-16</version>
   </parent>
 
-  <!-- TODO: Group ID and versions are tweaked due to https://github.com/jenkinsci/jenkinsfile-runner/pull/356 -->
-  <groupId>io.jenkins.jenkinsfile-runner</groupId>
+  <!-- TODO: Version is tweaked due to https://github.com/jenkinsci/jenkinsfile-runner/pull/356 -->
   <artifactId>ci.jenkins.io.runner</artifactId>
   <name>ci.jenkins.io Runner Plugins</name>
   <description>Jenkinsfile Runner reference implementation which emulates ci.jenkins.io</description>
-  <version>1.0-beta-16</version>
+  <version>1.0-beta-17</version>
 
   <properties>
     <jfr.name>ci.jenkins.io-runner</jfr.name>
@@ -45,6 +44,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- newer than the bundled version in the JFR BOM -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-multibranch</artifactId>
+      <version>2.22</version>
+    </dependency>
+
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
@@ -148,29 +154,32 @@
       <artifactId>docker-commons</artifactId>
       <version>1.17</version>
     </dependency>
-    <!--TODO: replace by Warnings NG once https://issues.jenkins-ci.org/browse/JENKINS-62963 is resolved-->
-    <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
-      <artifactId>findbugs</artifactId>
-      <version>5.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
-      <artifactId>checkstyle</artifactId>
-      <version>4.0.0</version>
-    </dependency>
-    <!--
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>warnings-ng</artifactId>
       <version>8.2.0</version>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr4-runtime</artifactId>
+      <version>4.7</version>
+    </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.7</version>
-    </dependency>        -->
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
This change finally includes the Warnings NG plugin into ci.jenkins.io-runner. It should allow running Jenkinsfile Runner with the recent Jenkins Pipeline Library versions.

FYI @timja @uhafner 