### PR TITLE
chore: remove `infra.retrieveMavenSettingsFile`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,35 +5,21 @@ properties([
 
 timeout(time: 2, unit: 'HOURS') {
     node ("linux") {
-        def settingsXml = "${pwd tmp: true}/settings-azure.xml"
-        def hasSettingsXml = false
         stage("Checkout") {
             checkout scm
-            if (infra.retrieveMavenSettingsFile(settingsXml)) {
-               // Running within Jenkins infra
-               hasSettingsXml = true
-            }
         }
 
         stage ("Build") {
             def makeCommand = "make clean build"
-            if (hasSettingsXml) {
-                makeCommand += " -e MVN_SETTINGS_FILE='${settingsXml}'"
-            }
             infra.runWithMaven(makeCommand)
         }
 
         stage("Run demo jobs") {
-            def runOptions = ""
-            if (hasSettingsXml) {
-                runOptions += " -e DOCKER_RUN_OPTS='-v ${settingsXml}:/root/.m2/settings.xml:ro'"
-            }
-
             stage("Smoke test") {
-              sh "make run ${runOptions}"
+              sh "make run"
             }
             stage("Plugin build") {
-              sh "make demo-plugin ${runOptions}"
+              sh "make demo-plugin"
             }
         }
     }


### PR DESCRIPTION
As this is last use of this function which has been removed from the shared pipeline library in https://github.com/jenkins-infra/pipeline-library/pull/589, and as there wasn't any azure-settings since a long time already, this PR removes it from this repository's Jenkinsfile.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
